### PR TITLE
json decode num precision #31

### DIFF
--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -24,7 +24,6 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import logging
-from decimal import Decimal
 from json import loads as _loads
 from hmac import new as _new
 from hashlib import sha512 as _sha512
@@ -201,7 +200,7 @@ class Poloniex(object):
                             },
                         timeout=self.timeout)
                 # return decoded json
-                return _loads(ret.text, parse_float=Decimal)
+                return _loads(ret.text, parse_float=str)
 
             except Exception as e:
                 raise e
@@ -216,7 +215,7 @@ class Poloniex(object):
                 ret = _post(
                         'https://poloniex.com/public?' + _urlencode(args),
                         timeout=self.timeout)
-                return _loads(ret.text, parse_float=Decimal)
+                return _loads(ret.text, parse_float=str)
             except Exception as e:
                 raise e
         else:
@@ -286,7 +285,7 @@ class Poloniex(object):
                         'end': str(end)
                         }),
                     timeout=self.timeout)
-            return _loads(ret.text, parse_float=Decimal)
+            return _loads(ret.text, parse_float=str)
         except Exception as e:
             raise e
 

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -24,6 +24,7 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import logging
+from decimal import Decimal
 from json import loads as _loads
 from hmac import new as _new
 from hashlib import sha512 as _sha512

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -199,12 +199,13 @@ class Poloniex(object):
                             'Key': self.Key
                             },
                         timeout=self.timeout)
-                # return decoded json
-                return _loads(ret.text, parse_float=str)
-
             except Exception as e:
                 raise e
-
+            # return decoded json
+            try:
+                return _loads(ret.text, parse_float=unicode)
+            except NameError:
+                return _loads(ret.text, parse_float=str)
             finally:
                 # increment nonce(no matter what)
                 self.nonce += 1
@@ -215,9 +216,12 @@ class Poloniex(object):
                 ret = _post(
                         'https://poloniex.com/public?' + _urlencode(args),
                         timeout=self.timeout)
-                return _loads(ret.text, parse_float=str)
             except Exception as e:
                 raise e
+            try:
+                return _loads(ret.text, parse_float=unicode)
+            except NameError:
+                return _loads(ret.text, parse_float=str)
         else:
             raise ValueError("Invalid Command!")
 
@@ -285,9 +289,12 @@ class Poloniex(object):
                         'end': str(end)
                         }),
                     timeout=self.timeout)
-            return _loads(ret.text, parse_float=str)
         except Exception as e:
             raise e
+        try:
+            return _loads(ret.text, parse_float=unicode)
+        except NameError:
+            return _loads(ret.text, parse_float=str)
 
     # --PRIVATE COMMANDS------------------------------------------------------
     def returnTradeHistory(self, pair):

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -201,14 +201,14 @@ class Poloniex(object):
                         timeout=self.timeout)
             except Exception as e:
                 raise e
+            finally:
+                # increment nonce(no matter what)
+                self.nonce += 1
             # return decoded json
             try:
                 return _loads(ret.text, parse_float=unicode)
             except NameError:
                 return _loads(ret.text, parse_float=str)
-            finally:
-                # increment nonce(no matter what)
-                self.nonce += 1
 
         # public?
         elif command in PUBLIC_COMMANDS:

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -200,7 +200,7 @@ class Poloniex(object):
                             },
                         timeout=self.timeout)
                 # return decoded json
-                return _loads(ret.text)
+                return _loads(ret.text, parse_float=Decimal)
 
             except Exception as e:
                 raise e
@@ -215,7 +215,7 @@ class Poloniex(object):
                 ret = _post(
                         'https://poloniex.com/public?' + _urlencode(args),
                         timeout=self.timeout)
-                return _loads(ret.text)
+                return _loads(ret.text, parse_float=Decimal)
             except Exception as e:
                 raise e
         else:
@@ -285,7 +285,7 @@ class Poloniex(object):
                         'end': str(end)
                         }),
                     timeout=self.timeout)
-            return _loads(ret.text)
+            return _loads(ret.text, parse_float=Decimal)
         except Exception as e:
             raise e
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 setup(name='poloniex',
-	version='0.2.0',
+	version='0.2.1',
 	description='Poloniex API wrapper for Python 2.7 and 3',
 	url='https://github.com/s4w3d0ff/python-poloniex',
 	author='s4w3d0ff',


### PR DESCRIPTION
pythons `json` by default uses `float` to parse decimals, this overwrites the default to `Decimal`