### PR TITLE
Unbreak a NameError when using Poloniex(coach=True)

### DIFF
--- a/poloniex/coach.py
+++ b/poloniex/coach.py
@@ -15,6 +15,7 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import logging
 from time import sleep, time, gmtime, strftime, strptime, localtime, mktime
 from calendar import timegm
 


### PR DESCRIPTION
Should resolve this:

```python
# Assume `polo` is a Poloniex(coach=True)

/home/j/.virtualenvs/ENV/lib/python3.5/site-packages/poloniex/__init__.py in marketTradeHist(self, pair, start, end)
    278         """
    279         if self._coaching:
--> 280             self.apicoach.wait()
    281         if not start:
    282             start = time()-self.HOUR

/home/j/.virtualenvs/ENV/lib/python3.5/site-packages/poloniex/coach.py in wait(self)
     78             # add 'now' to the front of 'timeBook', pushing other times back
     79             self._timeBook.insert(0, now)
---> 80             logging.info(
     81                 "Now: %d  Oldest Call: %d  Diff: %f sec" %
     82                 (now, self._timeBook[-1], now - self._timeBook[-1])

NameError: name 'logging' is not defined
```