### PR TITLE
simplify coaching using threading.Semaphore

### DIFF
--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -26,11 +26,13 @@
 from json import loads as _loads
 from hmac import new as _new
 from hashlib import sha512 as _sha512
+from time import time
+import logging
 # pip
 from requests import post as _post
 from requests import get as _get
 # local
-from .coach import Coach, time, logging
+from .coach import Coach
 # python 3 voodoo
 try:
     from urllib.parse import urlencode as _urlencode


### PR DESCRIPTION
The rate limiting performed by coaching is a bit complex. I integrated what I propose in this repository [here](https://github.com/enricobacis/limit) that comes from [this](http://stackoverflow.com/questions/30918772/rate-limiting-python-decorator) stack overflow discussion.

Basically the use of [`threading.Semaphore`](https://docs.python.org/2/library/threading.html#semaphore-objects) really simplifies the rate limiting task while providing solid guarantees. The [`semaphore.acquire`](https://docs.python.org/2/library/threading.html#threading.Semaphore.acquire) call blocks as long as the Semaphore is empty. The [`semaphore.release`](https://docs.python.org/2/library/threading.html#threading.Semaphore.release) is performed after `timeFrame` seconds. This way we can guarantee that in any timeframe we do not overpass the limits.

It works with both python 2.x and 3.x