### PR TITLE
copy/paste docs, matching args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 setup(name='poloniex',
-      version='0.3.6',
+      version='0.4.1',
       description='Poloniex API wrapper for Python 2.7 and 3',
       url='https://github.com/s4w3d0ff/python-poloniex',
       author='s4w3d0ff',

--- a/test.py
+++ b/test.py
@@ -35,7 +35,7 @@ class TestPolo(unittest.TestCase):
             self.polo('foo')
         # catch errors returned from poloniex.com
         with self.assertRaises(poloniex.PoloniexError):
-            self.polo.returnOrderBook(pair='atestfoo')
+            self.polo.returnOrderBook(currencyPair='atestfoo')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
buy/sell raise `PoloniexError` for bad order types
Arg name changes:
`Key, Secret == key, secret`
`coin == currency`
`pair == currencyPair`
`fromac == fromAccount`
`toac == toAccount`