### PR TITLE
fix public command naming to match poloniex api doc

### DIFF
--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -52,7 +52,7 @@ retryDelays = (0, 2, 5, 30)
 # Possible Commands
 PUBLIC_COMMANDS = [
     'returnTicker',
-    'return24hVolume',
+    'return24Volume',
     'returnOrderBook',
     'returnTradeHistory',
     'returnChartData',


### PR DESCRIPTION
In the readme: "Api commands have been 'mapped' into methods within the Poloniex class for your convenience."

Which might be confusing because the naming is different here. 

Poloniex doc: `return24Volume` vs `return24hVolume`
