### PR TITLE
fix naming of trade history public command

### DIFF
--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -54,7 +54,7 @@ PUBLIC_COMMANDS = [
     'returnTicker',
     'return24hVolume',
     'returnOrderBook',
-    'returnTradeHistory',
+    'marketTradeHist',
     'returnChartData',
     'returnCurrencies',
     'returnLoanOrders']


### PR DESCRIPTION
`returnTradeHistory` duplicate command in public and private. Changed it to `marketTradeHist` as it is the method that returns the past trade history for a given market (Public command).