### PR TITLE
Cleanup the websocket class

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,60 +77,31 @@ print(polo.returnTradeHistory('BTC_ETH'))
 You can also not use the 'helper' methods at all and use `poloniex.PoloniexBase` which only has `returnMarketHist` and `__call__` to make rest api calls.
 
 #### Websocket Usage:
-To connect to the websocket api just create a child class of `PoloniexSocketed` like so:
+To connect to the websocket api use the `PoloniexSocketed` class like so:
 ```python
 import poloniex
 import logging
+from time import sleep
 
-logging.basicConfig()
-
-class MySocket(poloniex.PoloniexSocketed):
-
-    def on_heartbeat(self, msg):
-        """
-        Triggers whenever we get a heartbeat message
-        """
-        print(msg)
-
-    def on_volume(self, msg):
-        """
-        Triggers whenever we get a 24hvolume message
-        """
-        print(msg)
-
-    def on_ticker(self, msg):
-        """
-        Triggers whenever we get a ticker message
-        """
-        print(msg)
-
-    def on_market(self, msg):
-        """
-        Triggers whenever we get a market ('currencyPair') message
-        """
-        print(msg)
-
-    def on_account(self, msg):
-        """
-        Triggers whenever we get an account message
-        """
-        print(msg)
-
-sock = MySocket()
 # helps show what is going on
-sock.logger.setLevel(logging.DEBUG)
-# start the websocket thread and subscribe to '24hvolume'
-sock.startws(subscribe=['24hvolume'])
+logging.basicConfig()
+poloniex.logger.setLevel(logging.DEBUG)
+
+def on_volume(data):
+    print(data)
+# make instance
+sock = poloniex.PoloniexSocketed()
+# start the websocket thread and subscribe to '24hvolume' setting the callback to 'on_volume'
+sock.startws(subscribe={'24hvolume': on_volume})
 # give the socket some time to init
-poloniex.sleep(5)
-# this won't work:
-#sock.subscribe('ticker')
-# use channel id to un/sub
-sock.subscribe('1002')
-poloniex.sleep(1)
-# unsub from ticker
-sock.unsubscribe('1002')
-poloniex.sleep(4)
+sleep(5)
+# use the channel name str or id int to subscribe/unsubscribe
+sock.subscribe(chan='ticker', callback=print)
+sleep(1)
+# unsub from ticker using id (str name can be use as well)
+sock.unsubscribe(1002)
+sleep(4)
+# stop websocket
 sock.stopws()
 
 ```
@@ -152,5 +123,12 @@ DEBUG:poloniex:Unsubscribed to ticker
 DEBUG:poloniex:Websocket Closed
 INFO:poloniex:Websocket thread stopped/joined
 ```
+You can also subscribe and start the websocket thread when creating an instance of `PoloniexSocketed` by using the `subscribe` and `start` args:
+```python
+
+sock = poloniex.PoloniexSocketed(subscribe={'24hvolume': print}, start=True)
+
+```
+
 
 **More examples of how to use websocket push API can be found [here](https://github.com/s4w3d0ff/python-poloniex/tree/master/examples).**

--- a/examples/websocket/dictTicker.py
+++ b/examples/websocket/dictTicker.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     polo = TickPolo()
     poloniex.logging.basicConfig()
     polo.logger.setLevel(poloniex.logging.DEBUG)
-    polo.startws(['ticker'])
+    polo.startws({'ticker': polo.on_ticker})
     for i in range(3):
         pprint(polo.ticker('BTC_LTC'))
         poloniex.sleep(10)

--- a/examples/websocket/stopLimit.py
+++ b/examples/websocket/stopLimit.py
@@ -9,7 +9,7 @@ class StopPoloniex(poloniex.PoloniexSocketed):
     def on_ticker(self, msg):
         data = [float(dat) for dat in msg]
         # check stop orders
-        mkt = self.channels[str(int(data[0]))]['name']
+        mkt = self._getChannelName(str(int(data[0])))
         la = data[2]
         hb = data[3]
         for id in self.stopOrders:
@@ -98,6 +98,6 @@ if __name__ == '__main__':
                       callback=callbk,
                       # remove or set 'test' to false to place real orders
                       test=True)
-    test.startws(['ticker'])
+    test.startws({'ticker': test.on_ticker})
     poloniex.sleep(120)
     test.stopws(3)

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -802,7 +802,7 @@ class PoloniexSocketed(Poloniex):
         else:
             self.channels[chan]['sub'] = True
             if callback:
-                self.channels[sub]['callback'] = callback
+                self.channels[chan]['callback'] = callback
             self.socket.send(_dumps({'command': 'subscribe',
                                      'channel': self.channels[chan]['id']}))
 
@@ -855,7 +855,7 @@ class PoloniexSocketed(Poloniex):
         self._running = False
         # unsubscribe from subs
         for chan in self.channels:
-            if self.channels[chan]['sub'] == True:
+            if 'sub' in self.channels[chan] and self.channels[chan]['sub'] == True:
                 self.unsubscribe(chan)
         sleep(wait)
         try:

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -683,7 +683,7 @@ class Poloniex(PoloniexBase):
 
 class PoloniexSocketed(Poloniex):
     """ Child class of Poloniex with support for the websocket api """
-    def __init__(self, key, secret, subscribe={}, start=False, *args, **kwargs):
+    def __init__(self, key=None, secret=None, subscribe={}, start=False, *args, **kwargs):
         super(PoloniexSocketed, self).__init__(key, secret, *args, **kwargs)
         self.socket = WebSocketApp(url="wss://api2.poloniex.com/",
                                    on_open=self.on_open,

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -683,8 +683,8 @@ class Poloniex(PoloniexBase):
 
 class PoloniexSocketed(Poloniex):
     """ Child class of Poloniex with support for the websocket api """
-    def __init__(self, *args, subscribe={}, start=False, **kwargs):
-        super(PoloniexSocketed, self).__init__(*args, **kwargs)
+    def __init__(self, key, secret, subscribe={}, start=False, *args, **kwargs):
+        super(PoloniexSocketed, self).__init__(key, secret, *args, **kwargs)
         self.socket = WebSocketApp(url="wss://api2.poloniex.com/",
                                    on_open=self.on_open,
                                    on_message=self.on_message,

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -700,7 +700,8 @@ class PoloniexSocketed(Poloniex):
                           'callback': self.on_heartbeat},
             }
         # add each market to channels list by id
-        for market in self.returnTicker():
+        tick = self.returnTicker()
+        for market in tick:
             self.channels[market] = {'id': str(tick[market]['id'])}
         # handle init subscribes
         if subscribe:

--- a/poloniex/__init__.py
+++ b/poloniex/__init__.py
@@ -716,7 +716,7 @@ class PoloniexSocketed(Poloniex):
 
     def on_open(self, *ws):
         for chan in self.channels:
-            if self.channels[chan]['sub']:
+            if 'sub' in self.channels[chan] and self.channels[chan]['sub']:
                 self.subscribe(chan)
 
     def on_message(self, data):
@@ -855,7 +855,7 @@ class PoloniexSocketed(Poloniex):
         self._running = False
         # unsubscribe from subs
         for chan in self.channels:
-            if 'sub' in self.channels[chan] and self.channels[chan]['sub'] == True:
+            if 'sub' in self.channels[chan] and self.channels[chan]['sub']:
                 self.unsubscribe(chan)
         sleep(wait)
         try:


### PR DESCRIPTION
make subscribing and callbacks more accessable, switch to using the string versions of the channels name instead of ids. Using the channel id still works for un/subscribing but it has to be passed as an int.